### PR TITLE
mint test: test for ErrAuth instead of ErrWard

### DIFF
--- a/test/gemfab-test.ts
+++ b/test/gemfab-test.ts
@@ -32,6 +32,6 @@ describe('gemfab', () => {
     want(bal.toNumber()).equal(100)
 
     const gembob = gem.connect(bob)
-    await fail('ErrWard()', gembob.mint, BOB, 100)
+    await fail('ErrAuth', gembob.mint, BOB, 100)
   })
 })


### PR DESCRIPTION
```
  1) gemfab
       mint ward:

      AssertionError: expected promise to be rejected with an error including 'ErrWard()' but got 'VM Exception while processing transaction: reverted with custom error \'ErrAuth("0x40c10f19")\''
      + expected - actual

      -VM Exception while processing transaction: reverted with custom error 'ErrAuth("0x40c10f19")'
      +ErrWard()
```