### PR TITLE
bump mocha deps for vulns

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@etherpacks/dpack": "^0.0.24",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
-    "@types/mocha": "^9.1.1",
+    "@types/mocha": "^9.0.0",
     "debug": "^4.3.2",
     "ethers": "^5.5.3",
     "hardhat": "^2.6.5",

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
   "devDependencies": {
     "@etherpacks/dpack": "^0.0.24",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
-    "@types/mocha": "^9.0.0",
+    "@types/mocha": "^9.1.1",
     "debug": "^4.3.2",
     "ethers": "^5.5.3",
     "hardhat": "^2.6.5",
     "minihat": "^0.0.4",
-    "ts-mocha": "^8.0.0",
+    "ts-mocha": "^10.0.0",
     "ts-node": "^10.4.0",
     "ts-standard": "^10.0.0",
     "typescript": "^4.4.3"


### PR DESCRIPTION
Bump mocha dependencies addressing 2 medium sev vulns in `nanoid` sub-dependency.

confirmed all `npm run test` tests passing on macOS.