### PR TITLE
name and symbol become bytes32

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.11",
   "main": "./dist/index.js",
   "scripts": {
-    "init": "git submodule update --init --recursive",
+    "init": "npm i",
     "build": "npm run build:sol && npm run build:ts",
     "build:ts": "npx tsc -b",
     "build:sol": "hardhat compile",

--- a/sol/gem.sol
+++ b/sol/gem.sol
@@ -19,8 +19,8 @@
 pragma solidity 0.8.13;
 
 contract Gem {
-    string  public name;
-    string  public symbol;
+    bytes32 public name;
+    bytes32 public symbol;
     uint256 public totalSupply;
     uint8   public constant decimals = 18;
 
@@ -48,7 +48,7 @@ contract Gem {
     error ErrUnderflow();
     error ErrWard();
 
-    constructor(string memory name_, string memory symbol_)
+    constructor(bytes32 name_, bytes32 symbol_)
       payable
     {
         name = name_;
@@ -177,7 +177,7 @@ contract GemFab {
 
     event Build(address indexed caller, address indexed gem);
 
-    function build(string memory name, string memory symbol)
+    function build(bytes32 name, bytes32 symbol)
       payable external returns (Gem gem)
     {
         gem = new Gem(name, symbol);
@@ -188,4 +188,3 @@ contract GemFab {
         return gem;
     }
 }
-

--- a/test/ERC20/ERC20.test.ts
+++ b/test/ERC20/ERC20.test.ts
@@ -8,12 +8,11 @@
 import {ethers} from "hardhat";
 import * as hh from "hardhat";
 import {snapshot, revert, send} from 'minihat'
-import {Signer, constants} from "ethers";
+import {Signer, constants, utils} from "ethers";
 
 const { expectEvent } = require('./helpers')
 const { expect } = require('chai');
 const expectRevert = async (f, msg) => { await expect(f).rejectedWith(msg) }
-const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 const { BigNumber } = ethers
 
 const {
@@ -43,8 +42,8 @@ let initialHolder, recipient, anotherAccount : Signer;
 
 describe('ERC20', () => {
 
-  const name = 'Gem';
-  const symbol = 'GEM';
+  const name = utils.formatBytes32String('Gem');
+  const symbol = utils.formatBytes32String('GEM');
 
   const initialSupply = BigNumber.from(1000);
 

--- a/test/ERC20/draft-ERC20Permit.test.ts
+++ b/test/ERC20/draft-ERC20Permit.test.ts
@@ -13,7 +13,7 @@ import {snapshot, revert, send} from 'minihat'
 const { expect } = require('chai');
 const expectRevert = async (f, msg) => { await expect(f).rejectedWith(msg) }
 const { BN } = require('bn.js')
-const { constants, BigNumber } = ethers
+const { constants, BigNumber, utils } = ethers
 
 const Permit = [
   { name: 'owner', type: 'address' },
@@ -28,8 +28,8 @@ const hre = require('hardhat');
 describe('ERC20Permit', () => {
   let initialHolder, spender, recipient, other;
 
-  const name = 'GemPermit';
-  const symbol = 'GEM';
+  const name = utils.formatBytes32String('GemPermit');
+  const symbol = utils.formatBytes32String('GEM');
   const version = '0';
 
   const initialSupply = BigNumber.from(100);

--- a/test/gemfab-test.ts
+++ b/test/gemfab-test.ts
@@ -1,7 +1,7 @@
 import * as hh from 'hardhat'
 import { ethers, artifacts, network } from 'hardhat'
 import { want, send, fail, snapshot, revert } from 'minihat'
-const { constants, BigNumber } = ethers
+const { constants, BigNumber, utils } = ethers
 
 import { test1D, test2D } from './helpers'
 import { bounds as _bounds } from './bounds'
@@ -42,8 +42,10 @@ describe('gemfab', () => {
     gemfab_type = await ethers.getContractFactory('GemFab', ali)
 
     gemfab = await gemfab_type.deploy()
-    const gemaddr = await gemfab.callStatic.build('Mock Cash', 'CASH')
-    await send(gemfab.build, 'Mock Cash', 'CASH')
+    const name = utils.formatBytes32String('Mock Cash');
+    const symbol = utils.formatBytes32String('CASH');
+    const gemaddr = await gemfab.callStatic.build(name, symbol)
+    await send(gemfab.build, name, symbol)
     gem = gem_type.attach(gemaddr)
 
     await snapshot(hh)
@@ -307,8 +309,10 @@ describe('gemfab', () => {
   });
 
   it('code doesnt change bc we dont use any immutable (in-code) vars', async()=>{
-    const gem2addr = await gemfab.callStatic.build('other', 'OTHER')
-    await send(gemfab.build, 'other', 'OTHER')
+    const name = utils.formatBytes32String('other');
+    const symbol = utils.formatBytes32String('OTHER');
+    const gem2addr = await gemfab.callStatic.build(name, symbol)
+    await send(gemfab.build, name, symbol)
     const gem2 = gem_type.attach(gem2addr)
     const gem_code = await ethers.provider.getCode(gem.address);
     const gem2_code = await ethers.provider.getCode(gem2.address);


### PR DESCRIPTION
Uses bytes32 for symbol and name. Should be considered if it's worth keeping them standard and converting between string and bytes32 when using dmap like bytes32(bytes(symbol_str))