### PR TITLE
log2 for caller event

### DIFF
--- a/sol/gem.sol
+++ b/sol/gem.sol
@@ -123,7 +123,7 @@ contract Gem {
             uint256 prevA   = allowance[src][msg.sender];
 
             emit Transfer(src, dst, wad);
-            assembly{ log1(0, 0, caller()) }
+            assembly{ log2(0, 0, 0, caller()) }
 
             if ( prevA != type(uint256).max ) {
                 allowance[src][msg.sender] = prevA - wad;


### PR DESCRIPTION
If we only use log1, then the caller address gets stored directly in the usual event signature spot. Putting a 0 there will make it so we can properly use the bloom filter to extract / distinguish caller events.